### PR TITLE
backport fallback font from lvgl 8.1

### DIFF
--- a/src/lv_draw/lv_draw_label.c
+++ b/src/lv_draw/lv_draw_label.c
@@ -433,6 +433,10 @@ LV_ATTRIBUTE_FAST_MEM static void lv_draw_letter(const lv_point_t * pos_p, const
         return;
     }
 
+    if (g.resolved_font) {
+        font_p = g.resolved_font;
+    }
+
     const uint8_t * map_p = lv_font_get_glyph_bitmap(font_p, letter);
     if(map_p == NULL) {
         LV_LOG_WARN("lv_draw_letter: character's bitmap not found");

--- a/src/lv_font/lv_font.c
+++ b/src/lv_font/lv_font.c
@@ -61,7 +61,18 @@ const uint8_t * lv_font_get_glyph_bitmap(const lv_font_t * font_p, uint32_t lett
 bool lv_font_get_glyph_dsc(const lv_font_t * font_p, lv_font_glyph_dsc_t * dsc_out, uint32_t letter,
                            uint32_t letter_next)
 {
-    return font_p->get_glyph_dsc(font_p, dsc_out, letter, letter_next);
+    dsc_out->resolved_font = NULL;
+    const lv_font_t * f = font_p;
+    bool found = false;
+    while(f) {
+        found = f->get_glyph_dsc(f, dsc_out, letter, letter_next);
+        if (found) {
+            dsc_out->resolved_font = f;
+            break;
+        }
+        f = f->fallback;
+    }
+    return found;
 }
 
 /**

--- a/src/lv_font/lv_font.h
+++ b/src/lv_font/lv_font.h
@@ -35,6 +35,7 @@ extern "C" {
 
 /** Describes the properties of a glyph. */
 typedef struct {
+    const struct _lv_font_struct *resolved_font; /**< Pointer to a font where the gylph was actually found after handling fallbacks*/
     uint16_t adv_w; /**< The glyph needs this space. Draw the next glyph after this width. */
     uint16_t box_w;  /**< Width of the glyph's bounding box*/
     uint16_t box_h;  /**< Height of the glyph's bounding box*/
@@ -70,6 +71,7 @@ typedef struct _lv_font_struct {
     int8_t underline_thickness;     /**< Thickness of the underline*/
 
     void * dsc;                     /**< Store implementation specific or run_time data or caching here*/
+    const struct _lv_font_struct * fallback;   /**< Fallback font for missing glyph. Resolved recursively */
 #if LV_USE_USER_DATA
     lv_font_user_data_t user_data;  /**< Custom user data for font. */
 #endif


### PR DESCRIPTION
This is from https://github.com/InfiniTimeOrg/InfiniTime/issues/1473

Fallback font enables us to add a very small addition glyph for languages that only contains a handfuls of alphabet outside of the ascii range. Without this, language specific fonts would need to duplicate everything in the ascii range.